### PR TITLE
Add basic notebook generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # notebook-generator
-מחולל אוטומטי למחברות לימוד לפיזיולוגיה, ביולוגיה, גנטיקה, ביוכימיה ומיקרוביולוגיה, לפי סגנון מותאם אישי.
+
+מחולל אוטומטי למחברות לימוד לפיזיולוגיה, ביולוגיה, גנטיקה, ביוכימיה ומיקרוביולוגיה.
+הכלי מקבל קבצי טקסט גולמי (כל קובץ מהווה פרק) ומייצר מחברת מרוכזת בסגנון מותאם אישית.
+
+## התקנה
+```bash
+pip install -e .
+```
+
+## שימוש בסיסי
+```bash
+python -m notebook_generator.cli chapter1.txt chapter2.txt -o notebook.md
+```
+
+## ייצוא
+ניתן לייצא את המחברת ל‑PDF או Word במידה והכלי `pandoc` מותקן:
+```python
+from notebook_generator.exporter import Exporter
+Exporter('notebook.md').to_pdf('notebook.pdf')
+```
+
+## צפייה אינטראקטיבית
+```python
+from notebook_generator.viewer import NotebookViewer
+NotebookViewer('notebook.md').serve()
+```

--- a/notebook_generator/cli.py
+++ b/notebook_generator/cli.py
@@ -1,0 +1,28 @@
+import argparse
+from pathlib import Path
+from .generator import NotebookGenerator
+
+
+def generate_notebook(files, output):
+    ng = NotebookGenerator()
+    notebook_parts = []
+    for file_path in files:
+        text = Path(file_path).read_text(encoding="utf-8")
+        topic = Path(file_path).stem
+        chapter = ng.add_chapter(topic, text)
+        notebook_parts.append(chapter)
+    notebook = '\n'.join(notebook_parts)
+    Path(output).write_text(notebook, encoding="utf-8")
+    print(f"Notebook written to {output}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate structured notebook from text files")
+    parser.add_argument('files', nargs='+', help='Input text files, each representing a chapter')
+    parser.add_argument('-o', '--output', default='notebook.md', help='Output markdown file')
+    args = parser.parse_args()
+    generate_notebook(args.files, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/notebook_generator/exporter.py
+++ b/notebook_generator/exporter.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import subprocess
+
+
+class Exporter:
+    """Export markdown notebooks to different formats using pandoc if available."""
+
+    def __init__(self, source: str):
+        self.source = Path(source)
+
+    def to_docx(self, output: str):
+        if not self.source.exists():
+            raise FileNotFoundError(self.source)
+        try:
+            subprocess.run([
+                'pandoc', str(self.source), '-o', output
+            ], check=True)
+            print(f"Exported DOCX to {output}")
+        except FileNotFoundError:
+            print("Pandoc not found. Please install pandoc to enable DOCX export")
+
+    def to_pdf(self, output: str):
+        if not self.source.exists():
+            raise FileNotFoundError(self.source)
+        try:
+            subprocess.run([
+                'pandoc', str(self.source), '-o', output
+            ], check=True)
+            print(f"Exported PDF to {output}")
+        except FileNotFoundError:
+            print("Pandoc not found. Please install pandoc to enable PDF export")

--- a/notebook_generator/generator.py
+++ b/notebook_generator/generator.py
@@ -1,0 +1,64 @@
+class NotebookGenerator:
+    """Simple notebook generator for medical students."""
+
+    GLOSSARY = {
+        "Neuron": "נוירון",
+        "Synapse": "סינפסה",
+        "DNA": "דנ\"א",
+        "RNA": "רנ\"א",
+        "Mitochondria": "מיטוכונדריה",
+    }
+
+    def __init__(self):
+        self.chapter_count = 0
+
+    def _bold_terms(self, text: str) -> str:
+        for term, hebrew in self.GLOSSARY.items():
+            text = text.replace(term, f"**{term}** ({hebrew})")
+        return text
+
+    def _split_paragraphs(self, text: str) -> list:
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        paragraphs = []
+        current = []
+        for line in lines:
+            if line.endswith((':', '-')):
+                if current:
+                    paragraphs.append(' '.join(current))
+                    current = []
+                paragraphs.append(line)
+            else:
+                current.append(line)
+        if current:
+            paragraphs.append(' '.join(current))
+        return paragraphs
+
+    def _format_section(self, heading: str, body: list) -> str:
+        formatted = [f"### {heading}"]
+        for paragraph in body:
+            bolded = self._bold_terms(paragraph)
+            formatted.append(bolded)
+        return '\n'.join(formatted)
+
+    def add_chapter(self, topic: str, raw_text: str) -> str:
+        self.chapter_count += 1
+        chapter_title = f"פרק {self.chapter_count}: {topic}"
+        sections = []
+        paragraphs = self._split_paragraphs(raw_text)
+        if paragraphs:
+            intro_lines = [self._bold_terms(p) for p in paragraphs[:2]]
+            sections.append('\n'.join(intro_lines))
+            paragraphs = paragraphs[2:]
+        current_heading = None
+        current_body = []
+        for para in paragraphs:
+            if para.endswith((':', '-')):
+                if current_heading:
+                    sections.append(self._format_section(current_heading, current_body))
+                    current_body = []
+                current_heading = para.rstrip(':-')
+            else:
+                current_body.append(para)
+        if current_heading:
+            sections.append(self._format_section(current_heading, current_body))
+        return f"# {chapter_title}\n\n" + '\n\n'.join(sections) + '\n'

--- a/notebook_generator/viewer.py
+++ b/notebook_generator/viewer.py
@@ -1,0 +1,29 @@
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+try:
+    import markdown
+except ImportError:  # pragma: no cover
+    markdown = None
+
+
+class NotebookViewer:
+    """Serve a markdown notebook as HTML for interactive reading."""
+
+    def __init__(self, markdown_file: str, port: int = 8000):
+        self.markdown_file = Path(markdown_file)
+        self.port = port
+
+    def serve(self):
+        if not self.markdown_file.exists():
+            raise FileNotFoundError(self.markdown_file)
+        if markdown is None:
+            raise ImportError("markdown package is required for viewing")
+        html = markdown.markdown(self.markdown_file.read_text(encoding="utf-8"))
+        html_page = f"<html><body>{html}</body></html>"
+        temp_html = self.markdown_file.with_suffix('.html')
+        temp_html.write_text(html_page, encoding="utf-8")
+        handler = SimpleHTTPRequestHandler
+        httpd = HTTPServer(('localhost', self.port), handler)
+        print(f"Serving on http://localhost:{self.port}")
+        httpd.serve_forever()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='notebook_generator',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        'markdown',
+    ],
+    entry_points={
+        'console_scripts': [
+            'notebook-generator=notebook_generator.cli:main'
+        ]
+    },
+)


### PR DESCRIPTION
## Summary
- implement `NotebookGenerator` with automatic bolding of medical terms and simple structure parsing
- add CLI for generating notebooks from chapter files
- add optional exporters for PDF/Word and HTML viewer
- provide setup configuration and usage instructions in Hebrew

## Testing
- `python -m notebook_generator.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_68533f14305c8328a2646804300cac36